### PR TITLE
feat: add tournament activation functionality and related tests

### DIFF
--- a/src/interfaces/Itournament.cairo
+++ b/src/interfaces/Itournament.cairo
@@ -14,6 +14,9 @@ pub trait Itournament<TContractState> {
         image_url: ByteArray,
     ) -> u64;
 
+    fn activate_tournament(ref self: TContractState, tournament_id: u64);
+    fn is_tournament_active(self: @TContractState, tournament_id: u64) -> bool;
+
     /// get tournament by id
     fn get_tournament(self: @TContractState, id: u64) -> Tournament;
 

--- a/src/structs/structs.cairo
+++ b/src/structs/structs.cairo
@@ -8,5 +8,6 @@ pub struct Tournament {
     pub entry_fee: u256,
     pub prize_pool: u256,
     pub image_url: ByteArray,
+    pub is_active: bool,
 }
 


### PR DESCRIPTION
closes #5 

### 🎯 Summary
Added `activateTournament` function to enable admin-controlled tournament activation, allowing user registration only after tournaments are activated.

### 🔧 Changes
- **Contract**: Added `activate_tournament()` function with admin-only access control
- **Struct**: Added `is_active` boolean field to Tournament struct  
- **Interface**: Added `activate_tournament()` and `is_tournament_active()` methods
- **Events**: Added `TournamentActivated` event emission
- **Tests**: Comprehensive test coverage for activation logic and access control

### ✅ Key Features
- ✨ Admin-only tournament activation
- 🛡️ Robust error handling (non-existent tournaments, double activation, unauthorized access)
- ⚡ Atomic state transitions
- 📊 Event tracking for activation
- 🧪 Full test coverage including edge cases

### 🧪 Testing
All tests pass including:
- Successful activation by admin
- Access control enforcement 
- Edge case handling (non-existent/already active tournaments)
- Multiple tournament scenarios
